### PR TITLE
Fixing MouseButtonMapper by adding VirtualKeyMaps to the MouseButtons. Adding Manual key entry form to not require recording inputs. Upgrading project to .NET 8.0

### DIFF
--- a/src/RSoft.MacroPad.BLL/Infrasturture/Model/MouseButton.cs
+++ b/src/RSoft.MacroPad.BLL/Infrasturture/Model/MouseButton.cs
@@ -3,18 +3,23 @@
     public enum MouseButton
     {
         [MouseValues(1,0)]
+        [VirtualKeyMap(VirtualKey.LButton)]
         Left,
 
         [MouseValues(4, 0)]
+        [VirtualKeyMap(VirtualKey.MButton)]
         Middle,
 
         [MouseValues(2, 0)]
+        [VirtualKeyMap(VirtualKey.RButton)]
         Right,
 
         [MouseValues(0, 1)]
+        [VirtualKeyMap(VirtualKey.Up)]
         ScrollUp,
 
         [MouseValues(0, 255)]
+        [VirtualKeyMap(VirtualKey.Down)]
         ScrollDown
     }
 }

--- a/src/RSoft.MacroPad.BLL/RSoft.MacroPad.BLL.csproj
+++ b/src/RSoft.MacroPad.BLL/RSoft.MacroPad.BLL.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>RSoft.MacroPad.BLL</AssemblyTitle>
@@ -8,6 +8,12 @@
     <Copyright>Copyright ©  2023</Copyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningLevel>9999</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningLevel>9999</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/src/RSoft.MacroPad/Controls/Compound/KeyRecorderTextBox.Designer.cs
+++ b/src/RSoft.MacroPad/Controls/Compound/KeyRecorderTextBox.Designer.cs
@@ -27,16 +27,17 @@
             panel1 = new System.Windows.Forms.Panel();
             checkBox1 = new System.Windows.Forms.CheckBox();
             toolTip1 = new System.Windows.Forms.ToolTip(components);
+            button3 = new System.Windows.Forms.Button();
             SuspendLayout();
             // 
             // button1
             // 
             button1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            button1.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            button1.Location = new System.Drawing.Point(807, 3);
-            button1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button1.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Bold);
+            button1.Location = new System.Drawing.Point(1153, 5);
+            button1.Margin = new System.Windows.Forms.Padding(6, 5, 6, 5);
             button1.Name = "button1";
-            button1.Size = new System.Drawing.Size(27, 27);
+            button1.Size = new System.Drawing.Size(39, 45);
             button1.TabIndex = 1;
             button1.Text = "X";
             toolTip1.SetToolTip(button1, "Clear all");
@@ -46,11 +47,11 @@
             // button2
             // 
             button2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            button2.Font = new System.Drawing.Font("Arial Narrow", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            button2.Location = new System.Drawing.Point(807, 37);
-            button2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F);
+            button2.Location = new System.Drawing.Point(1153, 62);
+            button2.Margin = new System.Windows.Forms.Padding(6, 5, 6, 5);
             button2.Name = "button2";
-            button2.Size = new System.Drawing.Size(27, 27);
+            button2.Size = new System.Drawing.Size(39, 45);
             button2.TabIndex = 1;
             button2.Text = "◄";
             toolTip1.SetToolTip(button2, "Delete last");
@@ -63,21 +64,21 @@
             panel1.BackColor = System.Drawing.Color.White;
             panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             panel1.Location = new System.Drawing.Point(0, 0);
-            panel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            panel1.Margin = new System.Windows.Forms.Padding(6, 5, 6, 5);
             panel1.Name = "panel1";
-            panel1.Size = new System.Drawing.Size(795, 144);
+            panel1.Size = new System.Drawing.Size(1135, 239);
             panel1.TabIndex = 2;
             // 
             // checkBox1
             // 
             checkBox1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             checkBox1.Appearance = System.Windows.Forms.Appearance.Button;
-            checkBox1.Font = new System.Drawing.Font("Arial Narrow", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            checkBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
             checkBox1.ForeColor = System.Drawing.Color.Red;
-            checkBox1.Location = new System.Drawing.Point(807, 70);
-            checkBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox1.Location = new System.Drawing.Point(1153, 117);
+            checkBox1.Margin = new System.Windows.Forms.Padding(6, 5, 6, 5);
             checkBox1.Name = "checkBox1";
-            checkBox1.Size = new System.Drawing.Size(27, 27);
+            checkBox1.Size = new System.Drawing.Size(39, 45);
             checkBox1.TabIndex = 0;
             checkBox1.Text = "●";
             checkBox1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -85,18 +86,33 @@
             checkBox1.UseVisualStyleBackColor = true;
             checkBox1.CheckedChanged += checkBox1_CheckedChanged;
             // 
+            // button3
+            // 
+            button3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button3.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F);
+            button3.Location = new System.Drawing.Point(1153, 172);
+            button3.Margin = new System.Windows.Forms.Padding(6, 5, 6, 5);
+            button3.Name = "button3";
+            button3.Size = new System.Drawing.Size(39, 45);
+            button3.TabIndex = 3;
+            button3.Text = "≡";
+            toolTip1.SetToolTip(button3, "Manually Enter Key");
+            button3.UseVisualStyleBackColor = true;
+            button3.Click += button3_Click;
+            // 
             // KeyRecorderTextBox
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(button3);
             Controls.Add(checkBox1);
             Controls.Add(panel1);
             Controls.Add(button2);
             Controls.Add(button1);
-            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            MinimumSize = new System.Drawing.Size(467, 92);
+            Margin = new System.Windows.Forms.Padding(6, 5, 6, 5);
+            MinimumSize = new System.Drawing.Size(667, 153);
             Name = "KeyRecorderTextBox";
-            Size = new System.Drawing.Size(838, 144);
+            Size = new System.Drawing.Size(1197, 240);
             ResumeLayout(false);
         }
 
@@ -106,5 +122,6 @@
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.CheckBox checkBox1;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.Button button3;
     }
 }

--- a/src/RSoft.MacroPad/Controls/Compound/KeyRecorderTextBox.cs
+++ b/src/RSoft.MacroPad/Controls/Compound/KeyRecorderTextBox.cs
@@ -9,8 +9,11 @@ using System.Windows.Forms;
 using RSoft.MacroPad.BLL.Infrasturture.Model;
 using RSoft.MacroPad.BLL.Infrasturture.Protocol.Mappers;
 using RSoft.MacroPad.Controls.Simple;
+using RSoft.MacroPad.Forms;
 using RSoft.MacroPad.Infrastructure;
 using RSoft.MacroPad.Model;
+using Windows.Win32;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace RSoft.MacroPad.Controls.Compound
 {
@@ -241,6 +244,30 @@ namespace RSoft.MacroPad.Controls.Compound
                 k == Keys.LShiftKey || k == Keys.RShiftKey ||
                 k == Keys.LControlKey || k == Keys.RControlKey ||
                 k == Keys.LWin || k == Keys.RWin;
+        }
+
+        private void button3_Click(object sender, EventArgs e)
+        {
+            var manualKeyForm = new ManualKeyForm();
+            manualKeyForm.ShowDialog();
+            if (manualKeyForm.DialogResult == DialogResult.OK && manualKeyForm.keySelected != VirtualKey.None)
+            {
+                var newModStroke = new KeyStroke
+                {
+                    Key = (Keys)manualKeyForm.keySelected,
+                    ScanCode = PInvoke.MapVirtualKey((uint)manualKeyForm.keySelected, MAP_VIRTUAL_KEY_TYPE.MAPVK_VK_TO_VSC),
+                    Operation = KeyStrokeOperation.Release,
+                    AltL = (manualKeyForm.modifier & Modifier.LeftAlt) != Modifier.None,
+                    AltR = (manualKeyForm.modifier & Modifier.RightAlt) != Modifier.None,
+                    CtrlL = (manualKeyForm.modifier & Modifier.LeftCtrl) != Modifier.None,
+                    CtrlR = (manualKeyForm.modifier & Modifier.RightCtrl) != Modifier.None,
+                    ShiftL = (manualKeyForm.modifier & Modifier.LeftShift) != Modifier.None,
+                    ShiftR = (manualKeyForm.modifier & Modifier.RightShift) != Modifier.None,
+                    WinL = (manualKeyForm.modifier & Modifier.LeftWin) != Modifier.None,
+                    WinR = (manualKeyForm.modifier & Modifier.RightWin) != Modifier.None,
+                };
+                _sequence.Add(newModStroke);
+            }
         }
     }
 }

--- a/src/RSoft.MacroPad/Forms/ManualKeyForm.Designer.cs
+++ b/src/RSoft.MacroPad/Forms/ManualKeyForm.Designer.cs
@@ -1,0 +1,222 @@
+﻿namespace RSoft.MacroPad.Forms
+{
+	partial class ManualKeyForm
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            gbModifiers = new System.Windows.Forms.GroupBox();
+            cbShiftL = new System.Windows.Forms.CheckBox();
+            cbCtrlL = new System.Windows.Forms.CheckBox();
+            cbWinR = new System.Windows.Forms.CheckBox();
+            cbShiftR = new System.Windows.Forms.CheckBox();
+            cbAltR = new System.Windows.Forms.CheckBox();
+            cbAltL = new System.Windows.Forms.CheckBox();
+            cbWinL = new System.Windows.Forms.CheckBox();
+            cbCtrlR = new System.Windows.Forms.CheckBox();
+            button1 = new System.Windows.Forms.Button();
+            listBox1 = new System.Windows.Forms.ListBox();
+            keyStrokeBindingSource = new System.Windows.Forms.BindingSource(components);
+            gbModifiers.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)keyStrokeBindingSource).BeginInit();
+            SuspendLayout();
+            // 
+            // gbModifiers
+            // 
+            gbModifiers.Controls.Add(cbShiftL);
+            gbModifiers.Controls.Add(cbCtrlL);
+            gbModifiers.Controls.Add(cbWinR);
+            gbModifiers.Controls.Add(cbShiftR);
+            gbModifiers.Controls.Add(cbAltR);
+            gbModifiers.Controls.Add(cbAltL);
+            gbModifiers.Controls.Add(cbWinL);
+            gbModifiers.Controls.Add(cbCtrlR);
+            gbModifiers.Location = new System.Drawing.Point(225, 12);
+            gbModifiers.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            gbModifiers.Name = "gbModifiers";
+            gbModifiers.Padding = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            gbModifiers.Size = new System.Drawing.Size(372, 210);
+            gbModifiers.TabIndex = 4;
+            gbModifiers.TabStop = false;
+            gbModifiers.Text = "Modifiers";
+            // 
+            // cbShiftL
+            // 
+            cbShiftL.AutoSize = true;
+            cbShiftL.Location = new System.Drawing.Point(12, 40);
+            cbShiftL.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbShiftL.Name = "cbShiftL";
+            cbShiftL.Size = new System.Drawing.Size(118, 29);
+            cbShiftL.TabIndex = 1;
+            cbShiftL.Text = "Left SHIFT";
+            cbShiftL.UseVisualStyleBackColor = true;
+            cbShiftL.Click += ModifierChanged;
+            // 
+            // cbCtrlL
+            // 
+            cbCtrlL.AutoSize = true;
+            cbCtrlL.Location = new System.Drawing.Point(12, 84);
+            cbCtrlL.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbCtrlL.Name = "cbCtrlL";
+            cbCtrlL.Size = new System.Drawing.Size(111, 29);
+            cbCtrlL.TabIndex = 1;
+            cbCtrlL.Text = "Left CTRL";
+            cbCtrlL.UseVisualStyleBackColor = true;
+            cbCtrlL.Click += ModifierChanged;
+            // 
+            // cbWinR
+            // 
+            cbWinR.AutoSize = true;
+            cbWinR.Location = new System.Drawing.Point(224, 172);
+            cbWinR.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbWinR.Name = "cbWinR";
+            cbWinR.Size = new System.Drawing.Size(120, 29);
+            cbWinR.TabIndex = 1;
+            cbWinR.Text = "Right WIN";
+            cbWinR.UseVisualStyleBackColor = true;
+            cbWinR.Click += ModifierChanged;
+            // 
+            // cbShiftR
+            // 
+            cbShiftR.AutoSize = true;
+            cbShiftR.Location = new System.Drawing.Point(224, 40);
+            cbShiftR.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbShiftR.Name = "cbShiftR";
+            cbShiftR.Size = new System.Drawing.Size(131, 29);
+            cbShiftR.TabIndex = 1;
+            cbShiftR.Text = "Right SHIFT";
+            cbShiftR.UseVisualStyleBackColor = true;
+            cbShiftR.Click += ModifierChanged;
+            // 
+            // cbAltR
+            // 
+            cbAltR.AutoSize = true;
+            cbAltR.Location = new System.Drawing.Point(224, 128);
+            cbAltR.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbAltR.Name = "cbAltR";
+            cbAltR.Size = new System.Drawing.Size(113, 29);
+            cbAltR.TabIndex = 1;
+            cbAltR.Text = "Right ALT";
+            cbAltR.UseVisualStyleBackColor = true;
+            cbAltR.Click += ModifierChanged;
+            // 
+            // cbAltL
+            // 
+            cbAltL.AutoSize = true;
+            cbAltL.Location = new System.Drawing.Point(12, 128);
+            cbAltL.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbAltL.Name = "cbAltL";
+            cbAltL.Size = new System.Drawing.Size(100, 29);
+            cbAltL.TabIndex = 1;
+            cbAltL.Text = "Left ALT";
+            cbAltL.UseVisualStyleBackColor = true;
+            cbAltL.Click += ModifierChanged;
+            // 
+            // cbWinL
+            // 
+            cbWinL.AutoSize = true;
+            cbWinL.Location = new System.Drawing.Point(12, 172);
+            cbWinL.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbWinL.Name = "cbWinL";
+            cbWinL.Size = new System.Drawing.Size(107, 29);
+            cbWinL.TabIndex = 1;
+            cbWinL.Text = "Left WIN";
+            cbWinL.UseVisualStyleBackColor = true;
+            cbWinL.Click += ModifierChanged;
+            // 
+            // cbCtrlR
+            // 
+            cbCtrlR.AutoSize = true;
+            cbCtrlR.Location = new System.Drawing.Point(224, 84);
+            cbCtrlR.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            cbCtrlR.Name = "cbCtrlR";
+            cbCtrlR.Size = new System.Drawing.Size(124, 29);
+            cbCtrlR.TabIndex = 1;
+            cbCtrlR.Text = "Right CTRL";
+            cbCtrlR.UseVisualStyleBackColor = true;
+            cbCtrlR.Click += ModifierChanged;
+            // 
+            // button1
+            // 
+            button1.Location = new System.Drawing.Point(490, 397);
+            button1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            button1.Name = "button1";
+            button1.Size = new System.Drawing.Size(107, 38);
+            button1.TabIndex = 5;
+            button1.Text = "Select";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += button1_Click;
+            // 
+            // listBox1
+            // 
+            listBox1.FormattingEnabled = true;
+            listBox1.ItemHeight = 25;
+            listBox1.Location = new System.Drawing.Point(12, 12);
+            listBox1.Name = "listBox1";
+            listBox1.Size = new System.Drawing.Size(205, 429);
+            listBox1.TabIndex = 6;
+            listBox1.SelectedIndexChanged += listBox1_SelectedIndexChanged;
+            // 
+            // keyStrokeBindingSource
+            // 
+            keyStrokeBindingSource.DataSource = typeof(Model.KeyStroke);
+            // 
+            // ManualKeyForm
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(611, 450);
+            Controls.Add(listBox1);
+            Controls.Add(button1);
+            Controls.Add(gbModifiers);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            Name = "ManualKeyForm";
+            ShowInTaskbar = false;
+            SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Select A Key";
+            gbModifiers.ResumeLayout(false);
+            gbModifiers.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)keyStrokeBindingSource).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+        private System.Windows.Forms.GroupBox gbModifiers;
+		private System.Windows.Forms.CheckBox cbShiftL;
+		private System.Windows.Forms.CheckBox cbCtrlL;
+		private System.Windows.Forms.CheckBox cbWinR;
+		private System.Windows.Forms.CheckBox cbShiftR;
+		private System.Windows.Forms.CheckBox cbAltR;
+		private System.Windows.Forms.CheckBox cbAltL;
+		private System.Windows.Forms.CheckBox cbWinL;
+		private System.Windows.Forms.CheckBox cbCtrlR;
+		private System.Windows.Forms.Button button1;
+		private System.Windows.Forms.ListBox listBox1;
+		private System.Windows.Forms.BindingSource keyStrokeBindingSource;
+	}
+}

--- a/src/RSoft.MacroPad/Forms/ManualKeyForm.cs
+++ b/src/RSoft.MacroPad/Forms/ManualKeyForm.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using RSoft.MacroPad.BLL.Infrasturture.Model;
+using RSoft.MacroPad.Infrastructure;
+
+namespace RSoft.MacroPad.Forms
+{
+    public partial class ManualKeyForm : Form
+    {
+        public VirtualKey keySelected { get; private set; }
+        public Modifier modifier = Modifier.None;
+
+        public Modifier Modifier
+        {
+            get => modifier;
+            set
+            {
+                modifier = value;
+                UpdateControls();
+            }
+        }
+
+        public ManualKeyForm()
+        {
+            InitializeComponent();
+
+            listBox1.DataSource = System.Enum.GetValues(typeof(VirtualKey));
+
+            cbShiftL.Tag = Modifier.LeftShift;
+            cbShiftR.Tag = Modifier.RightShift;
+            cbAltL.Tag = Modifier.LeftAlt;
+            cbAltR.Tag = Modifier.RightAlt;
+            cbCtrlL.Tag = Modifier.LeftCtrl;
+            cbCtrlR.Tag = Modifier.RightCtrl;
+            cbWinL.Tag = Modifier.LeftWin;
+            cbWinR.Tag = Modifier.RightWin;
+
+            UpdateControls();
+        }
+
+        private void UpdateControls()
+        {
+            foreach (var item in gbModifiers.Controls.As<CheckBox>())
+            {
+                item.Checked = ((Modifier)item.Tag & modifier) != Modifier.None;
+            }
+        }
+
+        private void ModifierChanged(object sender, EventArgs e)
+        {
+            var result = Modifier.None;
+
+            foreach (var item in gbModifiers.Controls.As<CheckBox>())
+            {
+                if (item.Checked)
+                    result |= (Modifier)item.Tag;
+            }
+
+            modifier = result;
+        }
+
+        private void listBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            keySelected = (VirtualKey)listBox1.SelectedItem;
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/src/RSoft.MacroPad/Forms/ManualKeyForm.resx
+++ b/src/RSoft.MacroPad/Forms/ManualKeyForm.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="keyStrokeBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>

--- a/src/RSoft.MacroPad/RSoft.MacroPad.csproj
+++ b/src/RSoft.MacroPad/RSoft.MacroPad.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>


### PR DESCRIPTION
Fixes an error that occurs when trying to send a mouse button configuration.
Error occurs in the following code in MouseButtonMapper due to there not being any virtual key attributes:
```
var attr = member.GetCustomAttribute<VirtualKeyMapAttribute>();
_map.Add((val, attr.Key));
```

Adding new ManualKeyForm that lets you manually select a key and modifiers to add to the key sequence. Useful if you want to add keypresses for keys that are not available on your keyboard. Button is placed just below the record button.
![Screenshot 2025-04-04 160907](https://github.com/user-attachments/assets/fcc2148d-7028-4447-8714-a9ddc74008ec)

Lastly upgrading the project to .NET 8.0